### PR TITLE
fix menu panel appearing on refresh

### DIFF
--- a/frontend/src/styles/components_styles/menuPanel.sass
+++ b/frontend/src/styles/components_styles/menuPanel.sass
@@ -1,10 +1,12 @@
 @use '../global/_main-color.sass' as main
+$animationDuration: 0.5s
 
 .menu-panel
     height: calc( 100vh - 4rem )
     width: 100vw
     background-color: main.$background-color-light
-    animation: fadeInAndShow 0.5s forwards
+    display: block
+    transition: opacity $animationDuration, height 0s
     .menu-panel__list
         height: 100%
         display: flex
@@ -24,11 +26,8 @@
                 padding: 1rem 0
                 background-color: transparent
 
-@keyframes fadeInAndShow
-  0%
-    opacity: 0
-    display: none
-  100%
-    opacity: 1
-    
-    
+.hidden
+  opacity: 0
+  height: 0
+  overflow: hidden
+  transition: opacity $animationDuration, height 0s ease-in-out $animationDuration

--- a/frontend/src/styles/index.sass
+++ b/frontend/src/styles/index.sass
@@ -42,9 +42,6 @@ button
 button:hover 
   border-color: main.$button-hover-border-color
 
-.hidden
-    animation: fadeOutAndHidden 0.5s forwards
-
 @media (prefers-color-scheme: dark) 
   :root 
     color: main.$text-color-dark
@@ -52,16 +49,4 @@ button:hover
   
   button 
     background-color: main.$button-background-color-dark
-  
-@keyframes fadeOutAndHidden
-  0%
-    opacity: 1
-    // height: auto
-  99%
-    opacity: 0
-    // height: auto
-  100%
-    opacity: 0
-    // height: 0
-    display: none
     


### PR DESCRIPTION
the original method of using keyfram and animation caused fadeout animation to be called whenever the page refreshed new method hide menupanel by setting height to 0 and use transition for fade in fade out it makes sure height transitioned immediatly when showing, and transition only after opacity finish transitioned when hidden this makes the animation part looks the same but react differently when refresh